### PR TITLE
feat: import FastMath into Moer

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,3 +8,6 @@
 [submodule "ext/stb/stb"]
 	path = ext/stb/stb
 	url = https://github.com/nothings/stb.git
+[submodule "ext/FastMath"]
+	path = ext/FastMath
+	url = https://github.com/NJUCG/FastMath.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.19)
 project(Moer LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
@@ -11,6 +11,10 @@ if (MSVC)
     # set unicode as character set
     # add_definitions(-DUNICODE -D_UNICODE)
 endif (MSVC)
+
+if(FM_SPEED_DEFAULT)
+    add_definitions(-DFM_SPEED_DEFAULT=${FM_SPEED_DEFAULT})
+endif (FM_SPEED_DEFAULT)
 
 option(EMBREE_USE_TBB "Enable TBB in embree." OFF)
 option(USE_SAMPLED_SPECTRUM "" OFF)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,6 +7,7 @@ source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${ALL_INCLUDE} ${ALL_SOURCES
 
 add_executable(${TARGET_NAME} ${ALL_INCLUDE} ${ALL_SOURCES})
 target_include_directories(${TARGET_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/src)
+target_include_directories(${TARGET_NAME} PUBLIC ${PROJECT_SOURCE_DIR}/ext/FastMath)
 
 add_dependencies(${TARGET_NAME} ext-copy)
 target_link_libraries(${TARGET_NAME} PUBLIC Moer-ext)

--- a/src/CoreLayer/ColorSpace/Color.h
+++ b/src/CoreLayer/ColorSpace/Color.h
@@ -14,6 +14,7 @@
 #include <vector>
 #include <cfloat>
 #include "CoreLayer/Math/Common.h"
+#include "FastMath.h"
 
 class RGB3;
 class XYZ3;
@@ -275,28 +276,28 @@ public:
 		return s * v;
 	}
 
-	/// @brief Call std::sqrt() on each component 
+	/// @brief Call fm::sqrt() on each component 
 	/// @attention Does not check whether the value on each component is greater than zero
 	friend CoefficientSpectrum sqrt(const CoefficientSpectrum& s) {
 		CoefficientSpectrum ret;
 		for (int i = 0; i < nSamples; i++)
-			ret[i] = std::sqrt(s[i]);
+			ret[i] = fm::sqrt(s[i]);
 		return ret;
 	}
 
-	/// @brief Call std::pow() on each component
+	/// @brief Call fm::pow() on each component
 	friend CoefficientSpectrum pow(const CoefficientSpectrum&s, double e) {
 		CoefficientSpectrum ret;
 		for (int i = 0; i < nSamples; i++)
-			ret[i] = std::pow(s[i], e);
+			ret[i] = fm::pow(s[i], e);
 		return ret;
 	}
 
-	/// @brief Call std::exp() on each component
+	/// @brief Call fm::exp() on each component
 	friend CoefficientSpectrum exp(const CoefficientSpectrum&s) {
 		CoefficientSpectrum ret;
 		for (int i = 0; i < nSamples; i++)
-			ret[i] = std::exp(s[i]);
+			ret[i] = fm::exp(s[i]);
 		return ret;
 	}
 

--- a/src/CoreLayer/ColorSpace/RGB3.cpp
+++ b/src/CoreLayer/ColorSpace/RGB3.cpp
@@ -12,6 +12,7 @@
 
 #include "Color.h"
 #include "Eigen/Dense"
+#include "FastMath.h"
 
 RGB3::RGB3() 
 {
@@ -65,7 +66,7 @@ RGB3 RGB3::operator/(const RGB3& rgb) const
 
 RGB3  RGB3::pow(double v) const
 {
-    return RGB3(std::pow(rgbData[0],v),std::pow(rgbData[1],v),std::pow(rgbData[2],v));
+    return RGB3(fm::pow(rgbData[0],v),fm::pow(rgbData[1],v),fm::pow(rgbData[2],v));
 }
 
 

--- a/src/CoreLayer/Geometry/Frame.h
+++ b/src/CoreLayer/Geometry/Frame.h
@@ -14,14 +14,14 @@
 
 #include "Geometry.h"
 #include "CoreLayer/Math/Common.h"
-
+#include "FastMath.h"
 
 static void coordinateSystem(const Normal3d &a, Vec3d  &b, Vec3d  &c) {
-    if (std::abs(a.x) > std::abs(a.y)) {
-        float invLen = 1.0f / std::sqrt(a.x * a.x + a.z * a.z);
+    if (fm::abs(a.x) > fm::abs(a.y)) {
+        float invLen = 1.0f / fm::sqrt(a.x * a.x + a.z * a.z);
         c = Vec3d (a.z * invLen, 0.0f, -a.x * invLen);
     } else {
-        float invLen = 1.0f / std::sqrt(a.y * a.y + a.z * a.z);
+        float invLen = 1.0f / fm::sqrt(a.y * a.y + a.z * a.z);
         c = Vec3d(0.0f, a.z * invLen, -a.y * invLen);
     }
     Vec3d  _a(a.x,a.y,a.z);
@@ -74,7 +74,7 @@ struct Frame {
         float temp = sinTheta2(v);
         if (temp <= 0.0f)
             return 0.0f;
-        return std::sqrt(temp);
+        return fm::sqrt(temp);
     }
 
     /** \brief Assuming that the given direction is in the local coordinate
@@ -83,7 +83,7 @@ struct Frame {
         float temp = 1 - v.z*v.z;
         if (temp <= 0.0f)
             return 0.0f;
-        return std::sqrt(temp) / v.z;
+        return fm::sqrt(temp) / v.z;
     }
 
     /** \brief Assuming that the given direction is in the local coordinate

--- a/src/CoreLayer/Geometry/Matrix.cpp
+++ b/src/CoreLayer/Geometry/Matrix.cpp
@@ -11,6 +11,7 @@
  */
 
 #include "Matrix.h"
+#include "FastMath.h"
 
 // Matrix4x4 impl
 
@@ -177,7 +178,7 @@ Matrix4x4 Matrix4x4::orthographic(double left, double right, double up, double d
 Matrix4x4 Matrix4x4::perspective(const Angle &fov, double aspect, double near, double far)
 {
 	/*
-	double cotHalfFov = (1 / std::tan(fov.getRad() / 2.0));
+	double cotHalfFov = (1 / fm::tan(fov.getRad() / 2.0));
 	Matrix4x4 retVal;
 	retVal.matrix << cotHalfFov, 0.0f, 0.0f, 0.0f,
 		0.0f, cotHalfFov / aspect, 0.0f, 0.0f,
@@ -186,7 +187,7 @@ Matrix4x4 Matrix4x4::perspective(const Angle &fov, double aspect, double near, d
 	return retVal;
 	*/
 	// zcx 6.10
-	double cotHalfFov = (1 / std::tan(fov.getRad() / 2.0));
+	double cotHalfFov = (1 / fm::tan(fov.getRad() / 2.0));
 	Matrix4x4 retVal;
 	retVal.matrix << cotHalfFov, 0, 0, 0,
 		      		 0, cotHalfFov * aspect, 0, 0,

--- a/src/CoreLayer/Geometry/Transform3d.cpp
+++ b/src/CoreLayer/Geometry/Transform3d.cpp
@@ -12,11 +12,12 @@
 
 #include "Transform3d.h"
 #include "CoreLayer/Math/Common.h"
+#include "FastMath.h"
 
 static Vec3d randomOrtho(const Vec3d &a)
 {
     Vec3d res;
-    if (std::abs(a.x) > std::abs(a.y))
+    if (fm::abs(a.x) > fm::abs(a.y))
         res = Vec3d(0.0f, 1.0f, 0.0f);
     else
         res = Vec3d(1.0f, 0.0f, 0.0f);

--- a/src/CoreLayer/Geometry/Vector.h
+++ b/src/CoreLayer/Geometry/Vector.h
@@ -11,7 +11,7 @@
  */
 #pragma once
 #include <assert.h>
-#include <cmath>
+#include "FastMath.h"
 #include <iostream>
 #include "Eigen/Dense"
 
@@ -88,7 +88,7 @@ struct TVector2 {
     }
 
     decltype(auto) length() const {
-        return std::sqrt(x*x + y*y);
+        return fm::sqrt(x*x + y*y);
     }
 
     bool operator==(const TVector2 &rhs) const {
@@ -123,7 +123,7 @@ decltype(auto) dot(const TVector2<T> &v1, const TVector2<T> &v2) {
 
 template <typename T>
 decltype(auto) absDot(const TVector2<T> &v1, const TVector2<T> &v2) {
-    return std::abs(v1.x*v2.x + v1.y * v2.y);
+    return fm::abs(v1.x*v2.x + v1.y * v2.y);
 }
 
 template <typename T>
@@ -231,7 +231,7 @@ struct TVector3 {
     }
     
     decltype(auto) length() const {
-        return std::sqrt(x*x + y*y + z*z);
+        return fm::sqrt(x*x + y*y + z*z);
     }
 
     bool operator==(const TVector3 &rhs) const {
@@ -265,7 +265,7 @@ decltype(auto) dot(const TVector3<T> &v1, const TVector3<T> &v2) {
 
 template <typename T>
 decltype(auto) absDot(const TVector3<T> &v1, const TVector3<T> &v2) {
-    return std::abs(v1.x * v2.x + v1.y * v2.y + v1.z * v2.z);
+    return fm::abs(v1.x * v2.x + v1.y * v2.y + v1.z * v2.z);
 }
 
 template <typename T>

--- a/src/CoreLayer/Math/Warp.h
+++ b/src/CoreLayer/Math/Warp.h
@@ -12,11 +12,12 @@
 
 #include "Common.h"
 #include "CoreLayer/Geometry/Geometry.h"
+#include "FastMath.h"
 
 static  double TentInverse(double x){
     if(x<=.5f)
-        return std::sqrt(2*x)-1;
-    return  1- std::sqrt(2-2*x);
+        return fm::sqrt(2*x)-1;
+    return  1- fm::sqrt(2-2*x);
 }
 inline   Point2d SquareToTent(const Point2d &sample) {
     Point2d  res(TentInverse(sample[0]), TentInverse(sample[1]));
@@ -24,14 +25,14 @@ inline   Point2d SquareToTent(const Point2d &sample) {
 }
 
 inline double SquareToTentPdf(const Point2d &p) {
-    return (1.0-std::abs(p[0])) * (1.0-std::abs(p[1]));
+    return (1.0-fm::abs(p[0])) * (1.0-fm::abs(p[1]));
 }
 
 inline Vec3d SquareToUniformSphere(const Point2d &sample) {
     float z = 1 - 2 * sample[0];
-    float r = std::sqrt(std::max((float )0, (float)1 - z * z));
+    float r = fm::sqrt(std::max((float )0, (float)1 - z * z));
     float phi = 2 * M_PI * sample[1];
-    return {r * std::cos(phi), r * std::sin(phi), z};
+    return {r * fm::cos(phi), r * fm::sin(phi), z};
 }
 
 inline  float SquareToUniformSpherePdf(const Vec3d &v) {
@@ -40,9 +41,9 @@ inline  float SquareToUniformSpherePdf(const Vec3d &v) {
 
 inline  Vec3d SquareToUniformHemisphere(const Point2d &sample) {
     float z = 1 - 2 * sample[0];
-    float r = std::sqrt(std::max((float )0, (float)1 - z * z));
+    float r = fm::sqrt(std::max((float )0, (float)1 - z * z));
     float phi = 2 * M_PI * sample[1];
-    return {r * std::cos(phi), r * std::sin(phi), std::abs(z)};
+    return {r * fm::cos(phi), r * fm::sin(phi), fm::abs(z)};
 }
 
 inline float SquareToUniformHemispherePdf(const Vec3d &v) {

--- a/src/FunctionLayer/Camera/Perspective.h
+++ b/src/FunctionLayer/Camera/Perspective.h
@@ -14,6 +14,7 @@
 #include "Camera.h"
 #include "CoreLayer/Geometry/Matrix.h"
 #include "CoreLayer/Adapter/JsonUtil.h"
+#include "FastMath.h"
 /**
  * @brief Base class for all perspective camera
  * @ingroup Camera
@@ -79,7 +80,7 @@ public:
         double xFov = getOptional(json,"fov",45);
         Vec2i resolution = getOptional(json,"resolution",Vec2i(512,512));
         double  aspectRatio = double(resolution.x) / resolution.y;
-        double distToFilm= 1.0f / std::tan(xFov * M_PI / 360);
+        double distToFilm= 1.0f / fm::tan(xFov * M_PI / 360);
 
         cameraToWorld =
                 Matrix4x4::lookAt(lookFrom, lookAt - lookFrom, up).inverse();

--- a/src/FunctionLayer/Camera/Thinlens.cpp
+++ b/src/FunctionLayer/Camera/Thinlens.cpp
@@ -1,6 +1,7 @@
 #include <cmath>
 #include "Thinlens.h"
 #include "CoreLayer/Math/Common.h"
+#include "FastMath.h"
 
 #define _USE_MATH_DEFINES
 
@@ -11,10 +12,10 @@ Ray ThinlensCamera::generateRay(const Point2i &filmResolution, const Point2i &pi
     Point3d pointOnFilm = sampleToFilm * Point3d (x, y, 0),
             pointOnFocalPlane = pointOnFilm * (focalDistance / pointOnFilm.z);
     // TODO warp the sample transform
-    float r = std::sqrt(sample.lens[0]),
+    float r = fm::sqrt(sample.lens[0]),
           theta = sample.lens[1] * 2 * M_PI;
     Point3d pointOnApeture = 
-        apertureRadius * Point3d(r * std::cos(theta), r * std::sin(theta), 0);       
+        apertureRadius * Point3d(r * fm::cos(theta), r * fm::sin(theta), 0);       
     Vec3d dir = normalize(pointOnFocalPlane - pointOnApeture);
         return Ray(
         cameraToWorld * pointOnApeture,

--- a/src/FunctionLayer/Film/ToneMapping.h
+++ b/src/FunctionLayer/Film/ToneMapping.h
@@ -12,6 +12,7 @@
 
 #include "CoreLayer/ColorSpace/Color.h"
 #include "CoreLayer/Geometry/Matrix.h"
+#include "FastMath.h"
 
 static inline  RGB3 filmicACES(const RGB3 &in)
 {
@@ -78,7 +79,7 @@ public:
                     if (c[i] < 0.0031308)
                         result[i] = 12.92*c[i];
                     else
-                        result[i] = 1.055*std::pow(c[i], 1.0f/2.4) - 0.055;
+                        result[i] = 1.055*fm::pow(c[i], 1.0f/2.4) - 0.055;
                 }
                 return result;
             } case Aces:{

--- a/src/FunctionLayer/Integrator/AbstractPathIntegrator.cpp
+++ b/src/FunctionLayer/Integrator/AbstractPathIntegrator.cpp
@@ -12,6 +12,7 @@
 
 #include "AbstractPathIntegrator.h"
 #include "FunctionLayer/Medium/Medium.h"
+#include "FastMath.h"
 
 AbstractPathIntegrator::AbstractPathIntegrator(
         std::shared_ptr<Camera> _camera, 
@@ -27,8 +28,8 @@ AbstractPathIntegrator::AbstractPathIntegrator(
 
 double AbstractPathIntegrator::MISWeight(double x, double y)
 {
-    double pow_x = std::pow(x, misWeightPower);
-    double pow_y = std::pow(y, misWeightPower);
+    double pow_x = fm::pow(x, misWeightPower);
+    double pow_y = fm::pow(y, misWeightPower);
     return pow_x / (pow_x + pow_y);
 }
 

--- a/src/FunctionLayer/Integrator/PathIntegrator-new.cpp
+++ b/src/FunctionLayer/Integrator/PathIntegrator-new.cpp
@@ -10,6 +10,7 @@
  */
 
 #include "PathIntegrator-new.h"
+#include "FastMath.h"
 
 PathIntegratorNew::PathIntegratorNew(std::shared_ptr<Camera> _camera,
                                      std::unique_ptr<Film> _film,
@@ -171,7 +172,7 @@ PathIntegratorLocalRecord PathIntegratorNew::evalScatter(std::shared_ptr<Scene> 
     {
         std::shared_ptr<BxDF> bxdf = its.material->getBxDF(its);
         Normal3d n = its.geometryNormal;
-        double wiDotN = std::abs(dot(n, dirScatter));
+        double wiDotN = fm::abs(dot(n, dirScatter));
         Vec3d wi = its.toLocal(dirScatter);
         Vec3d wo = its.toLocal(-ray.direction);
         return {
@@ -199,7 +200,7 @@ PathIntegratorLocalRecord PathIntegratorNew::sampleScatter(std::shared_ptr<Scene
         BxDFSampleResult bsdfSample = bxdf->sample(wo, sampler->sample2D(),false);
         double pdf = bsdfSample.pdf;
         Vec3d dirScatter = its.toWorld(bsdfSample.directionIn);
-        double wiDotN = std::abs(dot(dirScatter, n));
+        double wiDotN = fm::abs(dot(dirScatter, n));
         return {dirScatter, bsdfSample.s * wiDotN, pdf, BxDF::MatchFlags(bsdfSample.bxdfSampleType,BXDF_SPECULAR)};
     }
     else

--- a/src/FunctionLayer/Integrator/PathIntegrator.cpp
+++ b/src/FunctionLayer/Integrator/PathIntegrator.cpp
@@ -11,6 +11,7 @@
  */
 
 #include "PathIntegrator.h"
+#include "FastMath.h"
 
 PathIntegrator::PathIntegrator(
         std::shared_ptr<Camera> _camera, 
@@ -85,7 +86,7 @@ PathIntegratorLocalRecord PathIntegrator::evalScatter(std::shared_ptr<Scene> sce
     {
         std::shared_ptr<BxDF> bxdf = its.material->getBxDF(its);
         Normal3d n = its.geometryNormal;
-        double wiDotN = std::abs(dot(n, dirScatter));
+        double wiDotN = fm::abs(dot(n, dirScatter));
         Vec3d wi = its.toLocal(dirScatter);
         Vec3d wo = its.toLocal(-ray.direction);
         return {
@@ -113,7 +114,7 @@ PathIntegratorLocalRecord PathIntegrator::sampleScatter(std::shared_ptr<Scene> s
         BxDFSampleResult bsdfSample = bxdf->sample(wo, sampler->sample2D(),false);
         double pdf = bsdfSample.pdf;
         Vec3d dirScatter = its.toWorld(bsdfSample.directionIn);
-        double wiDotN = std::abs(dot(dirScatter, n));
+        double wiDotN = fm::abs(dot(dirScatter, n));
         return {dirScatter, bsdfSample.s * wiDotN, pdf, BxDF::MatchFlags(bsdfSample.bxdfSampleType,BXDF_SPECULAR)};
     }
     else

--- a/src/FunctionLayer/Integrator/VolPathIntegrator.cpp
+++ b/src/FunctionLayer/Integrator/VolPathIntegrator.cpp
@@ -11,6 +11,7 @@
 
 #include "VolPathIntegrator.h"
 #include "CoreLayer/Math/Warp.h"
+#include "FastMath.h"
 
 VolPathIntegrator::VolPathIntegrator(std::shared_ptr<Camera> _camera,
                                      std::unique_ptr<Film> _film,
@@ -223,7 +224,7 @@ PathIntegratorLocalRecord VolPathIntegrator::evalScatter(std::shared_ptr<Scene> 
     {
         std::shared_ptr<BxDF> bxdf = its.material->getBxDF(its);
         Normal3d n = its.geometryNormal;
-        double wiDotN = std::abs(dot(n, dirScatter));
+        double wiDotN = fm::abs(dot(n, dirScatter));
         Vec3d wi = its.toLocal(dirScatter);
         Vec3d wo = its.toLocal(-ray.direction);
         return {
@@ -251,7 +252,7 @@ PathIntegratorLocalRecord VolPathIntegrator::sampleScatter(std::shared_ptr<Scene
         BxDFSampleResult bsdfSample = bxdf->sample(wo, sampler->sample2D(),false);
         double pdf = bsdfSample.pdf;
         Vec3d dirScatter = its.toWorld(bsdfSample.directionIn);
-        double wiDotN = std::abs(dot(dirScatter, n));
+        double wiDotN = fm::abs(dot(dirScatter, n));
         return {dirScatter, bsdfSample.s * wiDotN, pdf, BxDF::MatchFlags(bsdfSample.bxdfSampleType,BXDF_SPECULAR)};
     }
     else

--- a/src/FunctionLayer/Light/InfiniteSphereCapLight.cpp
+++ b/src/FunctionLayer/Light/InfiniteSphereCapLight.cpp
@@ -1,12 +1,13 @@
 #include "InfiniteSphereCapLight.h"
+#include "FastMath.h"
 
 static inline Vec3d uniformSphericalCap(const Point2d & xi, double cosThetaMax) {
     double phi = xi.x * 2 * M_PI;
     double z = xi.y * ( 1.0f - cosThetaMax ) + cosThetaMax;
-    double r = std::sqrt(std::max(1.0 - z * z, 0.0));
+    double r = fm::sqrt(std::max(1.0 - z * z, 0.0));
     return Vec3d(
-            std::cos(phi) * r,
-            std::sin(phi) * r,
+            fm::cos(phi) * r,
+            fm::sin(phi) * r,
             z
     );
 }

--- a/src/FunctionLayer/Light/InfiniteSphereLight.cpp
+++ b/src/FunctionLayer/Light/InfiniteSphereLight.cpp
@@ -1,23 +1,24 @@
 #include "InfiniteSphereLight.h"
 #include "ResourceLayer/File/FileUtils.h"
+#include "FastMath.h"
 
 Vec3d UvToDirection(const Point2d & uv, double & sinTheta) {
     double phi = ( uv.x - 0.5 ) * 2 * M_PI;
     double theta = uv.y * M_PI;
-    sinTheta = std::sin(theta);
+    sinTheta = fm::sin(theta);
     return Vec3d(
-            std::cos(phi) * sinTheta,
-            -std::cos(theta),
-            std::sin(phi) * sinTheta);
+            fm::cos(phi) * sinTheta,
+            -fm::cos(theta),
+            fm::sin(phi) * sinTheta);
 }
 
 Point2d DirectionToUv(const Vec3d & direction) {
-    return Point2d(std::atan2(direction.z, direction.x) * 0.5 * INV_PI + 0.5, std::acos(- direction.y) * INV_PI);
+    return Point2d(fm::atan2(direction.z, direction.x) * 0.5 * INV_PI + 0.5, fm::acos(- direction.y) * INV_PI);
 }
 
 Point2d DirectionToUv(const Vec3d & direction, double & sinTheta) {
     sinTheta = sqrt(1 - direction.y * direction.y);
-    return Point2d(std::atan2(direction.z, direction.x) * 0.5 * INV_PI + 0.5, std::acos(- direction.y) * INV_PI);
+    return Point2d(fm::atan2(direction.z, direction.x) * 0.5 * INV_PI + 0.5, fm::acos(- direction.y) * INV_PI);
 }
 
 

--- a/src/FunctionLayer/Material/BxDF/BxDF.h
+++ b/src/FunctionLayer/Material/BxDF/BxDF.h
@@ -14,6 +14,7 @@
 #include "CoreLayer/ColorSpace/Color.h"
 #include "CoreLayer/Geometry/Geometry.h"
 #include "CoreLayer/Math/Warp.h"
+#include "FastMath.h"
 
 enum BXDFType {
     BXDF_REFLECTION = 1 << 0,
@@ -80,12 +81,12 @@ protected:
 // BSDF Inline Functions
 inline double CosTheta(const Vec3d &w) { return w.z; }
 inline double Cos2Theta(const Vec3d &w) { return w.z * w.z; }
-inline double AbsCosTheta(const Vec3d &w) { return std::abs(w.z); }
+inline double AbsCosTheta(const Vec3d &w) { return fm::abs(w.z); }
 inline double Sin2Theta(const Vec3d &w) {
     return std::max((double)0, (double)1 - Cos2Theta(w));
 }
 
-inline double SinTheta(const Vec3d &w) { return std::sqrt(Sin2Theta(w)); }
+inline double SinTheta(const Vec3d &w) { return fm::sqrt(Sin2Theta(w)); }
 
 inline double TanTheta(const Vec3d &w) { return SinTheta(w) / CosTheta(w); }
 

--- a/src/FunctionLayer/Material/BxDF/DielectricBxDF.cpp
+++ b/src/FunctionLayer/Material/BxDF/DielectricBxDF.cpp
@@ -13,6 +13,7 @@
 
 #include "DielectricBxDF.h"
 #include "Fresnel.h"
+#include "FastMath.h"
 Spectrum DielectricBxDF::f(const Vec3d &wo, const Vec3d &wi) const {
     return {0.f};
 }
@@ -26,19 +27,19 @@ BxDFSampleResult DielectricBxDF::sample(const Vec3d &wo, const Point2d &sample) 
 
     double  eta = wo.z < 0.0 ? ior : invIor;
     double cosThetaT;
-    double F= Fresnel::dielectricReflectance(eta, std::abs(wo.z), cosThetaT);
+    double F= Fresnel::dielectricReflectance(eta, fm::abs(wo.z), cosThetaT);
     double reflectionProbability= F;
     if(sample[0]<=reflectionProbability) {
         result.directionIn = Frame::reflect(wo);
         result.pdf = reflectionProbability;
         result.bxdfSampleType = BXDFType(BXDF_REFLECTION | BXDF_SPECULAR);
-        result.s = specularR * F / std::abs(result.directionIn.z);
+        result.s = specularR * F / fm::abs(result.directionIn.z);
     }
     else {
         result.directionIn = Vec3d (-eta*wo.x,-eta*wo.y,-std::copysign(cosThetaT,wo.z));
         result.pdf = 1-reflectionProbability;
         result.bxdfSampleType = BXDFType(BXDF_TRANSMISSION | BXDF_SPECULAR);
-        result.s= specularT * (1-F)/ std::abs(result.directionIn.z);
+        result.s= specularT * (1-F)/ fm::abs(result.directionIn.z);
     }
     return  result;
 }
@@ -115,7 +116,7 @@ double RoughDielectricBxDF::pdf(const Vec3d & out, const Vec3d & in, bool reflec
     else {
         double sqrtDenom = dot(out, wh) * eta +  dot(in, wh);
         double dWhDWi =
-                std::abs( dot(in, wh)) / (sqrtDenom * sqrtDenom);
+                fm::abs( dot(in, wh)) / (sqrtDenom * sqrtDenom);
         pdf =   whPdf * (1-F) * dWhDWi;
     }
     return pdf;
@@ -139,7 +140,7 @@ Spectrum RoughDielectricBxDF::f(const Vec3d & out, const Vec3d & in, bool reflec
         double whDotIn =  dot(wh,in);
         double whDotOut = dot(wh,out);
         double sqrtDeom = eta * whDotOut  +  whDotIn;
-        return glossyT * ( 1 - F) * D * G * std::abs(
+        return glossyT * ( 1 - F) * D * G * fm::abs(
                 whDotIn * whDotOut  /
                 (in.z * out.z * sqrtDeom * sqrtDeom)
         );

--- a/src/FunctionLayer/Material/BxDF/Fresnel.h
+++ b/src/FunctionLayer/Material/BxDF/Fresnel.h
@@ -10,7 +10,7 @@
  */
 
 #pragma  once
-#include "math.h"
+#include "FastMath.h"
 #include "CoreLayer/Geometry/Geometry.h"
 
 namespace Fresnel {
@@ -25,7 +25,7 @@ namespace Fresnel {
             cosThetaT = 0.0;
             return 1.0;
         }
-        cosThetaT = std::sqrt(std::max(1.0 - sinThetaTSq, 0.0));
+        cosThetaT = fm::sqrt(std::max(1.0 - sinThetaTSq, 0.0));
 
         double Rs = (eta*cosThetaI - cosThetaT)/(eta*cosThetaI + cosThetaT);
         double Rp = (eta*cosThetaT - cosThetaI)/(eta*cosThetaT + cosThetaI);
@@ -45,8 +45,8 @@ namespace Fresnel {
         double sinThetaIQu = sinThetaISq*sinThetaISq;
 
         double innerTerm = eta*eta - k*k - sinThetaISq;
-        double aSqPlusBSq = std::sqrt(std::max(innerTerm*innerTerm + 4.0f*eta*eta*k*k, 0.0));
-        double a = std::sqrt(std::max((aSqPlusBSq + innerTerm)*0.5, 0.0));
+        double aSqPlusBSq = fm::sqrt(std::max(innerTerm*innerTerm + 4.0f*eta*eta*k*k, 0.0));
+        double a = fm::sqrt(std::max((aSqPlusBSq + innerTerm)*0.5, 0.0));
 
         double Rs = ((aSqPlusBSq + cosThetaISq) - (2.0*a*cosThetaI))/
                    ((aSqPlusBSq + cosThetaISq) + (2.0*a*cosThetaI));

--- a/src/FunctionLayer/Material/BxDF/MicrofacetDistribution.cpp
+++ b/src/FunctionLayer/Material/BxDF/MicrofacetDistribution.cpp
@@ -2,6 +2,7 @@
 #include "CoreLayer/Geometry/Frame.h"
 
 #include "BxDF.h"
+#include "FastMath.h"
 
 std::shared_ptr<MicrofacetDistribution> LoadDistributionFromJson(const Json & json){
     if(!json.contains("distribution"))
@@ -28,7 +29,7 @@ double MicrofacetDistribution::Pdf(const Vec3d & wo, const Vec3d & wh, const Vec
 double BeckmannDistribution::roughnessToAlpha(double roughness) const {
     roughness = std::max(roughness, (double)1e-3);
     return roughness;
-    double x = std::log(roughness);
+    double x = fm::log(roughness);
     return 1.62142f + 0.819955f * x + 0.1734f * x * x +
            0.0171201f * x * x * x + 0.000640711f * x * x * x * x;
 }
@@ -39,7 +40,7 @@ double BeckmannDistribution::D(const Vec3d & wh, const Vec2d & alphaXY) const {
     double tan2Theta = Tan2Theta(wh);
     if (std::isinf(tan2Theta)) return 0.;
     double cos4Theta = Cos2Theta(wh) * Cos2Theta(wh);
-    return std::exp(-tan2Theta * (Cos2Phi(wh) / (alphaX * alphaX) +
+    return fm::exp(-tan2Theta * (Cos2Phi(wh) / (alphaX * alphaX) +
                                   Sin2Phi(wh) / (alphay * alphay))) /
            (M_PI * alphaX * alphay * cos4Theta);
 }
@@ -48,11 +49,11 @@ double BeckmannDistribution::Lambda(const Vec3d & w, const Vec2d & alphaXY) cons
     double alphaX =alphaXY.x;
     double alphay =alphaXY.y;
 
-    double absTanTheta = std::abs(TanTheta(w));
+    double absTanTheta = fm::abs(TanTheta(w));
     if (std::isinf(absTanTheta)) return 0.;
     // Compute _alpha_ for direction _w_
     double alpha =
-            std::sqrt(Cos2Phi(w) * alphaX * alphaX + Sin2Phi(w) * alphay * alphay);
+            fm::sqrt(Cos2Phi(w) * alphaX * alphaX + Sin2Phi(w) * alphay * alphay);
     double a = 1 / (alpha * absTanTheta);
     if (a >= 1.6f) return 0;
     return (1 - 1.259f * a + 0.396f * a * a) / (3.535f * a + 2.181f * a * a);
@@ -68,22 +69,22 @@ Vec3d BeckmannDistribution::Sample_wh(const Vec3d & wo, const Point2d & u, const
     //todo add support sample visible area
     if(!sampleVisibleArea){
         if(alphaX == alphay){
-            tan2Theta = -std::log(1-u[0]) * alphaX * alphaX ;
+            tan2Theta = -fm::log(1-u[0]) * alphaX * alphaX ;
             phi = u[1] * 2 * M_PI;
         }
         else {
 
-            phi = std::atan(alphay / alphaX *
-                            std::tan(2 * M_PI * u[1] + 0.5 * M_PI));
+            phi = fm::atan(alphay / alphaX *
+                            fm::tan(2 * M_PI * u[1] + 0.5 * M_PI));
             if (u[1] > 0.5) phi += M_PI;
-            double sinPhi = std::sin(phi), cosPhi = std::cos(phi);
+            double sinPhi = fm::sin(phi), cosPhi = fm::cos(phi);
             double alphaX2 = alphaX * alphaX, alphay2 = alphay * alphay;
-            tan2Theta = -std::log(1-u[0]) /
+            tan2Theta = -fm::log(1-u[0]) /
                         (cosPhi * cosPhi / alphaX2 + sinPhi * sinPhi / alphay2);
         }
-        double cosTheta = std::sqrt(1 / (1+tan2Theta));
-        double sinTheta = std::sqrt(1 / (1+1/tan2Theta));
-        Vec3d  wh = Vec3d(sinTheta*std::cos(phi),sinTheta*std::sin(phi),cosTheta);
+        double cosTheta = fm::sqrt(1 / (1+tan2Theta));
+        double sinTheta = fm::sqrt(1 / (1+1/tan2Theta));
+        Vec3d  wh = Vec3d(sinTheta*fm::cos(phi),sinTheta*fm::sin(phi),cosTheta);
         return wh;
     }
         // see https://hal.inria.fr/hal-00996995v1/document // todo
@@ -154,20 +155,20 @@ Vec3d GGXDistribution::Sample_wh(const Vec3d & wo, const Point2d & u, const Vec2
         double cosTheta, phi = (2 * M_PI) * u[1];
         if (alphaX == alphaY) {
             double tanTheta2 = alphaX * alphaY * u[0] / (1.0f - u[0]);
-            cosTheta = 1 / std::sqrt(1 + tanTheta2);
+            cosTheta = 1 / fm::sqrt(1 + tanTheta2);
         } else {
             phi =
-                    std::atan(alphaY / alphaX * std::tan(2 * M_PI * u[1] + .5f * M_PI));
+                    fm::atan(alphaY / alphaX * fm::tan(2 * M_PI * u[1] + .5f * M_PI));
             if (u[1] > .5f) phi += M_PI;
-            double sinPhi = std::sin(phi), cosPhi = std::cos(phi);
+            double sinPhi = fm::sin(phi), cosPhi = fm::cos(phi);
             const double alphaX2 = alphaX * alphaX, alphaY2 = alphaY * alphaY;
             const double alpha2 =
                     1 / (cosPhi * cosPhi / alphaX2 + sinPhi * sinPhi / alphaY2);
             double tanTheta2 = alpha2 * u[0] / (1 - u[0]);
-            cosTheta = 1 / std::sqrt(1 + tanTheta2);
+            cosTheta = 1 / fm::sqrt(1 + tanTheta2);
         }
         double sinTheta =
-                std::sqrt(std::max((double )0., (double )1. - cosTheta * cosTheta));
+                fm::sqrt(std::max((double )0., (double )1. - cosTheta * cosTheta));
         Vec3d wh = Vec3d(sinTheta * cos(phi), sinTheta * sin(phi), cosTheta);
         return  wh;
     }

--- a/src/FunctionLayer/Material/BxDF/MirrorBxDF.cpp
+++ b/src/FunctionLayer/Material/BxDF/MirrorBxDF.cpp
@@ -11,6 +11,7 @@
  */
 
 #include "MirrorBxDF.h"
+#include "FastMath.h"
 
 
 Spectrum MirrorBxDF::f(const Vec3d &wo, const Vec3d &wi) const {
@@ -26,7 +27,7 @@ BxDFSampleResult MirrorBxDF::sample(const Vec3d &wo, const Point2d &sample) cons
     result.bxdfSampleType = BXDFType(BXDF_REFLECTION | BXDF_SPECULAR);
     result.directionIn=  Vec3d (-wo.x,-wo.y,wo.z);
     result.pdf=1;
-    result.s = 1 / std::abs(result.directionIn.z);
+    result.s = 1 / fm::abs(result.directionIn.z);
     return  result;
 }
 

--- a/src/FunctionLayer/Material/DisneyBSDF.cpp
+++ b/src/FunctionLayer/Material/DisneyBSDF.cpp
@@ -3,6 +3,7 @@
 #include "BxDF/Fresnel.h"
 #include  "FunctionLayer/Texture/TextureFactory.h"
 #include "FunctionLayer/Distribution/Distribution.h"
+#include "FastMath.h"
 
 #include <variant>
 
@@ -286,7 +287,7 @@ double pdfDisneyBXDFOP::operator ()(const DisneyGlass & disneyBXDF) {
 
         double sqrtDenom = dot(out, wh) * eta +  dot(in, wh);
         double dWhDWi =
-                std::abs( dot(in, wh)) / (sqrtDenom * sqrtDenom);
+                fm::abs( dot(in, wh)) / (sqrtDenom * sqrtDenom);
         pdf = disneyBXDF.distrib.Pdf(out,wh,alpha) * (1-F) * dWhDWi;
     }
     return pdf;

--- a/src/FunctionLayer/Medium/Homogeneous.cpp
+++ b/src/FunctionLayer/Medium/Homogeneous.cpp
@@ -1,4 +1,5 @@
 #include "Homogeneous.h"
+#include "FastMath.h"
 
 bool HomogeneousMedium::sampleDistance(MediumSampleRecord *mRec, 
                                        const Ray &ray, 
@@ -9,13 +10,13 @@ bool HomogeneousMedium::sampleDistance(MediumSampleRecord *mRec,
     //TODO sample a channel first
     //! Might crush becaust bad optional access
 
-    double dist = -std::log(1 - x) / mDensity;
+    double dist = -fm::log(1 - x) / mDensity;
 
     if (dist < its->t) {
         //* Scatter in medium
         mRec->marchLength = dist;
         mRec->scatterPoint = ray.at(dist);
-        mRec->pdf = mDensity * std::exp(-mDensity * dist);
+        mRec->pdf = mDensity * fm::exp(-mDensity * dist);
         mRec->sigmaA = Spectrum{(1 - mAlbedo) * mDensity};
         mRec->sigmaS = Spectrum{mAlbedo * mDensity};
         mRec->tr = evalTransmittance(ray.origin, mRec->scatterPoint);
@@ -23,7 +24,7 @@ bool HomogeneousMedium::sampleDistance(MediumSampleRecord *mRec,
     } else {
         //* Pass through this medium without collision
         mRec->marchLength = its->t;
-        mRec->pdf = std::exp(-mDensity * its->t);
+        mRec->pdf = fm::exp(-mDensity * its->t);
         mRec->tr = evalTransmittance(ray.origin, its->position);
         return false;
     }
@@ -33,5 +34,5 @@ Spectrum HomogeneousMedium::evalTransmittance(Point3d from,
                                               Point3d dest) const 
 {
     double dist = (dest - from).length();
-    return Spectrum{std::exp(-mDensity * dist)};
+    return Spectrum{fm::exp(-mDensity * dist)};
 }

--- a/src/FunctionLayer/Shape/Cube.cpp
+++ b/src/FunctionLayer/Shape/Cube.cpp
@@ -1,4 +1,5 @@
 #include "Cube.h"
+#include "FastMath.h"
 
 Cube::Cube(const Json &json) : Entity(json) {
     position = matrix->getTranslate() * Point3d(.0f);
@@ -43,13 +44,13 @@ std::optional<Intersection> Cube::intersect(const Ray &r) const {
         int minDimension = -1;
         double minBias = 1e10;
         for (int i = 0; i < 3; ++i) {
-            if (std::abs(pMin[i] - hitpoint_[i]) < minBias) {
+            if (fm::abs(pMin[i] - hitpoint_[i]) < minBias) {
                 minDimension = 2 * i;
-                minBias = std::abs(std::abs(pMin[i] - hitpoint_[i]));
+                minBias = fm::abs(fm::abs(pMin[i] - hitpoint_[i]));
             }
-            if (std::abs(pMax[i] - hitpoint_[i]) < minBias) {
+            if (fm::abs(pMax[i] - hitpoint_[i]) < minBias) {
                 minDimension = 2 * i + 1;
-                minBias = std::abs(pMax[i] - hitpoint_[i]);
+                minBias = fm::abs(pMax[i] - hitpoint_[i]);
             }
         }
         assert(minDimension != -1);

--- a/src/FunctionLayer/Shape/Quad.cpp
+++ b/src/FunctionLayer/Shape/Quad.cpp
@@ -1,5 +1,6 @@
 #include "Quad.h"
 #include "FunctionLayer/Intersection.h"
+#include "FastMath.h"
 
 Quad::Quad(const Json & json) : Entity(json) {
     _base = getOptional(json,"base",Point3d(0,0,0));
@@ -13,7 +14,7 @@ Quad::Quad(const Json & json) : Entity(json) {
 std::optional <Intersection> Quad::intersect(const Ray & r) const {
     Vec3d  n = normalize(cross(_edge1,_edge0));;
     double dotW = dot(r.direction,n);
-    if(std::abs(dotW)<EPSILON){
+    if(fm::abs(dotW)<EPSILON){
         return std::nullopt;
     }
     double t = dot(n,(_base - r.origin))/dotW;

--- a/src/FunctionLayer/Texture/ImageTexture.h
+++ b/src/FunctionLayer/Texture/ImageTexture.h
@@ -11,13 +11,13 @@
  */
 #pragma once
 
-#include <cmath>
 #include "CoreLayer/ColorSpace/Color.h"
 #include "ResourceLayer/File/Image.h"
 #include "ResourceLayer/ResourceManager.h"
 #include "FunctionLayer/Intersection.h"
 #include "Texture.h"
 #include "TextureMapping.h"
+#include "FastMath.h"
 
 enum class WrapMode
 {
@@ -159,7 +159,7 @@ std::vector < double > ImageTexture < Treturn, Tmemory >::sphericalWeighs( ) {
     std::vector<double> weights(_w*_h);
     for (int y = 0, idx = 0; y < _h; ++y) {
         double rowWeight = 1.0;
-        rowWeight *= std::sin((y*M_PI)/_h);
+        rowWeight *= fm::sin((y*M_PI)/_h);
         for (int x = 0; x < _w; ++x, ++idx)
         {
             Treturn val = imageSampler->texel(Point2i(x,y));


### PR DESCRIPTION
将FastMath的数学库功能集成进Moer中，具体来说：
1. 在ext中添加了submode，依赖NJUCG/FastMath
2. 将src中`#include <cmath>` `#include <math.h>` 等替换为 `#include "FastMath.h"`，并将对应函数 `std::xxx(...)` 替换为 `fm::xxx(...)` 
3. 修改了CMakelists中的include path，define等，并修复一个与FastMath无关但一直未改的cmake_minimum_required(VERSION 3.12)的问题。

注：
1. 目前集成FastMath仅考虑数学库部分`FastMath.h` ，暂不考虑用（没有速度优势的） `VecMat.h` 替换Eigen
2. 测试渲染testball和classroom能够正常出图且肉眼观察与集成前无差异，不过基本没有速度上的提升（14.4s->14.2s 396s->392s 且不能排除是否为测量误差），估计是因为数学函数计算本身不是性能瓶颈。
3. 使用上，FastMath默认是`ESpeedNormal`选项，可以在cmake命令行中手动指定默认速度，例如 `cmake .. -DFM_SPEED_DEFAULT=ESpeedFast3` `cmake .. -DFM_SPEED_DEFAULT=ESpeedStd` （选项含义可见于NJUCG/FastMath/readme.md）