### PR TITLE
feature: Add glint material

### DIFF
--- a/src/CoreLayer/Geometry/BoundingBox.h
+++ b/src/CoreLayer/Geometry/BoundingBox.h
@@ -116,3 +116,84 @@ static BoundingBox3<BaseType> BoundingBoxPointUnion(const BoundingBox3<BaseType>
 }
 
 using BoundingBox3f = BoundingBox3<double>;
+
+//Axis-aligned bounding box 2D base type
+template <typename BaseType>
+class BoundingBox2
+{
+public:
+	TPoint2<BaseType> pMin;			
+	TPoint2<BaseType> pMax;
+
+	BoundingBox2(){
+		pMin[0] = pMin[1] = std::numeric_limits<BaseType>::max();
+		pMax[0] = pMax[1] = std::numeric_limits<BaseType>::lowest();
+	}
+
+	BoundingBox2(TPoint2<BaseType> _p)
+	{
+		pMin = pMax = _p;
+	}
+
+	BoundingBox2(TPoint2<BaseType> _pMin, TPoint2<BaseType> _pMax)
+	{
+		pMin = _pMin;
+		pMax = _pMax;
+
+		// corner case: bounding box not exist
+		if(pMin.x > pMax.x || pMin.y > pMax.y){
+			pMin[0] = pMin[1] = std::numeric_limits<BaseType>::max();
+			pMax[0] = pMax[1] = std::numeric_limits<BaseType>::lowest();
+		}
+	}
+
+	// caculate area
+	inline double getSurfaceArea(){
+		double x = pMax[0] - pMin[0];
+		double y = pMax[1] - pMin[1];
+		
+		return x * y;
+	}
+
+	// judge if overlap
+	inline bool overlap(BoundingBox2 &box){
+		if(pMin[0] > box.pMax[0] || pMax[0] < box.pMin[0])
+			return false;
+		if(pMin[1] > box.pMax[1] || pMax[1] < box.pMin[1])
+			return false;
+		return true;
+	}
+
+	// judge if contains some box
+	inline bool contains(BoundingBox2 &box){
+		if(pMin[0] > box.pMin[0] || pMax[0] < box.pMax[0])
+			return false;
+		if(pMin[1] > box.pMin[1] || pMax[1] < box.pMax[1])
+			return false;
+		return true;
+	}
+
+	inline TPoint2<BaseType> getCenter(){
+		return TPoint2<BaseType>((pMin[0] + pMax[0]) / 2, (pMin[1] + pMax[1]) / 2);
+	}
+};
+
+template <typename BaseType>
+static BoundingBox2<BaseType> BoundingBoxUnionIntersect(const BoundingBox2<BaseType>& b1, 
+														const BoundingBox2<BaseType>& b2)
+{
+	TPoint2<BaseType> _pMin(std::max(b1.pMin[0], b2.pMin[0]), std::max(b1.pMin[1], b2.pMin[1]));
+	TPoint2<BaseType> _pMax(std::min(b1.pMax[0], b2.pMax[0]), std::min(b1.pMax[1], b2.pMax[1]));
+	return BoundingBox2(_pMin, _pMax);
+}
+
+template <typename BaseType>
+static BoundingBox2<BaseType> BoundingBoxPointUnion(const BoundingBox2<BaseType>& b1,
+                                                    const TPoint2<BaseType>& p)
+{
+    TPoint2<BaseType> _pMin(std::min(b1.pMin[0], p[0]), std::min(b1.pMin[1], p[1]));
+    TPoint2<BaseType> _pMax(std::max(b1.pMax[0], p[0]), std::max(b1.pMax[1], p[1]));
+    return BoundingBox2(_pMin, _pMax);
+}
+
+using BoundingBox2d = BoundingBox2<double>;

--- a/src/CoreLayer/Ray/Ray.cpp
+++ b/src/CoreLayer/Ray/Ray.cpp
@@ -15,6 +15,7 @@
 Ray::Ray(const Point3d &_origin, const Vec3d &_direction, double _timeMin, double _timeMax) : origin(_origin),
                                                                                               direction(_direction)
 {
+    hasDifferential = false;    
 	timeMin = _timeMin;
 	timeMax = _timeMax;
 }

--- a/src/CoreLayer/Ray/Ray.h
+++ b/src/CoreLayer/Ray/Ray.h
@@ -22,6 +22,11 @@ struct Ray
 	Point3d origin;		///< The origin of the ray
 	Vec3d direction;	///< The direction of the ray
 
+	// ray differential
+	bool hasDifferential; 
+	Point3d origin_x, origin_y;
+	Vec3d direction_x, direction_y;
+
 	double timeMin;		///< The time when the shutter open
 	double timeMax;		///< The time when the shutter close
 	Point3d at(double t) const ;

--- a/src/FunctionLayer/Camera/CameraFactory.cpp
+++ b/src/FunctionLayer/Camera/CameraFactory.cpp
@@ -1,6 +1,7 @@
 #include "CameraFactory.h"
 #include "Camera.h"
 #include "Pinhole.h"
+#include "DifferentialPinhole.h"
 
 namespace CameraFactory {
 
@@ -10,7 +11,9 @@ std::shared_ptr<T> cameraCreatorHelper(const Json &json) {
 }
 
 static std::unordered_map<std::string, std::function<std::shared_ptr<Camera>(const Json &)>> cameraMap{
-    {"pinhole", cameraCreatorHelper<PinholeCamera>}};
+    {"pinhole", cameraCreatorHelper<PinholeCamera>},
+    {"differential_pinhole", cameraCreatorHelper<DifferentialPinholeCamera>}
+};
 
 std::shared_ptr<Camera> LoadCameraFromJson(const Json &json) {
     return cameraMap[json["type"]](json);

--- a/src/FunctionLayer/Camera/DifferentialPinhole.cpp
+++ b/src/FunctionLayer/Camera/DifferentialPinhole.cpp
@@ -1,0 +1,27 @@
+#include"DifferentialPinhole.h"
+
+Ray DifferentialPinholeCamera::generateRay(const Point2i &filmResolution, const Point2i &pixelPosition, const CameraSample &sample) const {
+    double x = (double)(pixelPosition.x + sample.xy.x) / filmResolution.x,
+           y = (double)(pixelPosition.y + sample.xy.y) / filmResolution.y;
+    
+    Point3d pointOnFilm = sampleToFilm * Point3d {x, y, 0},
+            origin = Point3d {0, 0, 0};
+    
+    Vec3d dir = cameraToWorld * normalize(pointOnFilm - origin);
+    Vec3d dirX = cameraToWorld * normalize((sampleToFilm * Point3d {x + 1.f, y, 0}) - origin);
+    Vec3d dirY = cameraToWorld * normalize((sampleToFilm * Point3d {x, y + 1.f, 0}) - origin);
+    
+    origin = cameraToWorld * origin;
+
+    Ray ret = Ray(origin, dir);
+
+    ret.hasDifferential = true;
+    ret.direction_x = dirX;
+    ret.direction_y = dirY;
+    ret.origin_x = ret.origin_y = origin;
+
+    return ret;
+}
+
+DifferentialPinholeCamera::DifferentialPinholeCamera(const Json & json) : PerspectiveCamera(json) {
+}

--- a/src/FunctionLayer/Camera/DifferentialPinhole.h
+++ b/src/FunctionLayer/Camera/DifferentialPinhole.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "Perspective.h"
+#include "CoreLayer/Adapter/JsonUtil.h"
+
+// pinhole with differential
+class DifferentialPinholeCamera : public PerspectiveCamera {
+public:
+    DifferentialPinholeCamera() = default;
+    DifferentialPinholeCamera(
+        const Point3d &lookFrom, 
+        const Point3d &lookAt, 
+        const Vec3d &up,
+        double xFov,
+        double aspectRatio,
+        double distToFilm
+    ) : PerspectiveCamera(lookFrom, lookAt, up, xFov, aspectRatio, distToFilm) { }
+
+    DifferentialPinholeCamera(const Json & json);
+
+    virtual Ray generateRay(const Point2i &filmResolution, 
+                            const Point2i &pixelPosition, 
+                            const CameraSample &sample) const override;
+};

--- a/src/FunctionLayer/Integrator/AbstractPathIntegrator.cpp
+++ b/src/FunctionLayer/Integrator/AbstractPathIntegrator.cpp
@@ -66,6 +66,9 @@ Spectrum AbstractPathIntegrator::Li(const Ray &initialRay, std::shared_ptr<Scene
         }
 
         Intersection its = itsOpt.value();
+        if(ray.hasDifferential){
+            its.computeRayDifferential(ray);
+        }
 
         // RUSSIAN ROULETTE
         nBounce++;

--- a/src/FunctionLayer/Intersection.h
+++ b/src/FunctionLayer/Intersection.h
@@ -36,6 +36,10 @@ struct Intersection
 	Vec3d dpdu, dpdv;
 	Normal3d dndu, dndv;
 
+	// raydifferential
+	float dudx, dvdx, dudy, dvdy;
+	Vec3d dpdx, dpdy;
+
 	// std::shared_ptr<Entity> object;
 	const Entity *object;
 
@@ -53,5 +57,69 @@ struct Intersection
 	Vec3d toWorld(const Vec3d &d) const
 	{
 		return shFrame.toWorld(d);
+	}
+
+	// compute differential, reference implementation in lite
+	void computeRayDifferential(const Ray &ray){
+		
+		dudx = 0.f;
+		dudy = 0.f;
+		dvdx = 0.f;
+		dvdy = 1.f;
+		dpdx = Vec3d(0.f);
+		dpdy = Vec3d(0.f);
+
+		Point3d p = position;
+		Vec3d n = geometryNormal;
+		Vec3d ox = Vec3d{ray.origin_x[0], ray.origin_x[1], ray.origin_x[2]};
+		Vec3d oy = Vec3d{ray.origin_y[0], ray.origin_y[1], ray.origin_y[2]};
+
+		double distance = dot(n, Vec3d(p[0], p[1], p[2]));
+		double tx = (distance - dot(n, ox)) / (dot(n, ray.direction_x));
+		if(std::isinf(tx) || std::isnan(tx))
+			return;
+		double ty = (distance - dot(n, oy)) / (dot(n, ray.direction_y));
+		if(std::isinf(ty) || std::isnan(ty))
+			return;
+		
+		dpdx = normalize((ray.origin_x + tx * ray.direction_x) - p);
+		dpdy = normalize((ray.origin_y + ty * ray.direction_y) - p);
+
+		int dim[2];
+		if (std::abs(n[0]) > std::abs(n[1]) && std::abs(n[0]) > std::abs(n[2])) {
+			dim[0] = 1;
+			dim[1] = 2;
+		} else if (std::abs(n[1]) > std::abs(n[2])) {
+			dim[0] = 0;
+			dim[1] = 2;
+		} else {
+			dim[0] = 0;
+			dim[1] = 1;
+		}
+
+		float A[2][2] = {{dpdu[dim[0]], dpdv[dim[0]]},
+						{dpdu[dim[1]], dpdv[dim[1]]}};
+		float Bx[2] = {dpdx[dim[0]], dpdx[dim[1]]};
+		float By[2] = {dpdy[dim[0]], dpdy[dim[1]]};
+
+		auto solveLinearSystem2x2 = [](const float A[2][2], const float B[2],
+										float *x0, float *x1) {
+			float det = A[0][0] * A[1][1] - A[0][1] * A[1][0];
+			if (std::abs(det) < 1e-10f)
+				return false;
+			*x0 = (A[1][1] * B[0] - A[0][1] * B[1]) / det;
+			*x1 = (A[0][0] * B[1] - A[1][0] * B[0]) / det;
+			if (std::isnan(*x0) || std::isnan(*x1))
+				return false;
+			return true;
+		};
+
+		if (!solveLinearSystem2x2(A, Bx, &dudx, &dvdx))
+			dudx = dvdx = .0f;
+		if (!solveLinearSystem2x2(A, Bx, &dudy, &dvdy))
+			dudy = dvdy = .0f;
+			
+		return;
+
 	}
 };

--- a/src/FunctionLayer/Material/BxDF/GlintBxDF.cpp
+++ b/src/FunctionLayer/Material/BxDF/GlintBxDF.cpp
@@ -1,0 +1,177 @@
+#include "GlintBxDF.h"
+#include "Fresnel.h"
+#include "CoreLayer/Geometry/Frame.h"
+
+GlintBxDF::GlintBxDF(Vec3d _eta, Vec3d _k, Spectrum _albedo, double _uRoughness, double _vRoughness,Intersection _it,
+                                       std::shared_ptr < MicrofacetDistribution > _distrib) :
+                                        eta(_eta),k(_k),albedo(_albedo),it(_it),distrib(std::move(_distrib))
+                                       {
+    alphaXY = Vec2d(distrib->roughnessToAlpha(_uRoughness),distrib->roughnessToAlpha(_vRoughness));
+                                       }
+
+BxDFSampleResult GlintBxDF::sample(const Vec3d & out, const Point2d & sample) const {
+    BxDFSampleResult result{};
+    if(CosTheta(out)<0){
+        return result;
+    }
+    Vec3d wh = distrib->Sample_wh(out,sample,alphaXY);
+    Vec3d in = Frame::reflect(out,wh);
+    if (dot(wh,out) < 0 || CosTheta(in)<0)
+    {
+        result.s=Spectrum(0);
+        return result;
+    }
+    double mPdf =distrib->Pdf(out,wh,alphaXY);
+    auto woDoth = dot(out,wh);
+    double pdf = mPdf*0.25f/woDoth;
+    Spectrum F = Fresnel::conductorReflectance(eta, k, woDoth);
+    result.pdf = pdf;
+    result.s = ( F * distrib->G(out,in,alphaXY)*distrib->D(wh,alphaXY))/abs(4 * out.z * in.z);
+    result.directionIn = in;
+    result.bxdfSampleType = BXDFType(BXDF_REFLECTION | BXDF_GLOSSY);
+    return result;
+}
+
+double GlintBxDF::pdf(const Vec3d & out, const Vec3d & in) const {
+    if ( CosTheta(out) < 0 || CosTheta(in) < 0) return 0;
+    Vec3d wh = normalize(out + in);
+    return distrib->Pdf(out, wh,alphaXY) / (4 * dot(out, wh));
+}
+
+// count particles number fall in tex area
+double GlintBxDF::count_spatial(BoundingBox2d &queryBox) const {
+    uint32_t countNum = 0, queryDepth = 0;
+    std::vector<SpatialNode> queue;
+    queue.push_back(std::make_pair(BoundingBox2d(Point2d(0.f, 0.f), Point2d(1.f, 1.f)), SPATIAL_SAMPLE_NUM));
+    SpatialNode node;
+    BoundingBox2d clipBox;
+    double p, w;
+    //bfs
+    while (!queue.empty()){
+        node = queue.back();
+        queue.pop_back();
+        if(!queryBox.overlap(node.first) || node.second <= 0){
+            continue;
+        }
+        else if(queryBox.contains(node.first)){
+            countNum += node.second;
+        }
+        else{
+            p = countNum / SPATIAL_SAMPLE_NUM;
+            // approximation
+            if(sqrt(node.second * p * (1 - p)) < EPSILON * countNum){
+                clipBox = node.first;
+                clipBox = BoundingBoxUnionIntersect(queryBox, clipBox);
+                countNum += (uint32_t)(node.second * clipBox.getSurfaceArea() / node.first.getSurfaceArea());
+            }
+            else{
+                if(queryDepth >= MAX_QUERY_DEPTH){
+                    break;
+                }
+                // split box
+                w = 1 - queryPs[queryDepth][0] - queryPs[queryDepth][1] - queryPs[queryDepth][2];
+                Point2d center = node.first.getCenter(), pMin = node.first.pMin, pMax = node.first.pMax;
+                queue.push_back(std::make_pair(
+                    BoundingBox2(pMin, center), 
+                    (uint32_t)(node.second * queryPs[queryDepth][0])));
+                queue.push_back(std::make_pair(
+                    BoundingBox2(Point2d(pMin[0], center[1]), Point2d(center[0],pMax[1])), 
+                    (uint32_t)(node.second * queryPs[queryDepth][1])));
+                queue.push_back(std::make_pair(
+                    BoundingBox2(Point2d(center[0], pMin[1]), Point2d(pMax[0],center[1])), 
+                    (uint32_t)(node.second * queryPs[queryDepth][2])));
+                queue.push_back(std::make_pair(
+                    BoundingBox2(center, pMax), 
+                    (uint32_t)(node.second * w)));
+                queryDepth++;
+            }
+        }
+    }
+    assert(countNum < SPATIAL_SAMPLE_NUM);
+    return (double)countNum / SPATIAL_SAMPLE_NUM;
+    
+
+}
+
+// count particles number fall in cone
+double GlintBxDF::count_direction(const Vec3d &wi, const Vec3d & wo) const{
+    uint32_t countNum = 0, queryDepth = 1;
+    std::vector<DirectionNode> queue;
+    ConicQuery query(wi, wo);
+    queue.push_back(std::make_pair(DirTriangle(Point2d(0.f, 0.f), Point2d(M_PI / 2, 0.f), Point2d(0.f, M_PI /2)),
+                                    (uint32_t)(DIRECTION_SAMPLE_NUM * queryPs[0].x)));
+    queue.push_back(std::make_pair(DirTriangle(Point2d(M_PI / 2, 0.f), Point2d(M_PI, 0.f), Point2d(0.f, M_PI /2)),
+                                    (uint32_t)(DIRECTION_SAMPLE_NUM * queryPs[0].y)));
+    queue.push_back(std::make_pair(DirTriangle(Point2d(M_PI , 0.f), Point2d(M_PI * 3 / 2, 0.f), Point2d(0.f, M_PI /2)),
+                                    (uint32_t)(DIRECTION_SAMPLE_NUM * queryPs[0].z)));
+    queue.push_back(std::make_pair(DirTriangle(Point2d(M_PI * 3 / 2, 0.f), Point2d(M_PI * 2, 0.f), Point2d(0.f, M_PI /2)),
+                                    (uint32_t)(DIRECTION_SAMPLE_NUM * (1 - queryPs[0].x - queryPs[0].y - queryPs[0].z))));
+    DirectionNode node;
+    double p;
+    //bfs
+    while (!queue.empty()){
+        node = queue.back();
+        queue.pop_back();
+        // not overlap
+        if((!(query.inConic(node.first[0]) || query.inConic(node.first[1]) || 
+                                query.inConic(node.first[2]))) || node.second <= 0){
+            continue;
+        }
+        // contains
+        else if(query.conicContain(node.first)){
+            countNum += node.second;
+        }
+        else{
+            p = countNum / SPATIAL_SAMPLE_NUM;
+            // approximation
+            // todo: calculate the ratio of area
+            if(sqrt(node.second * p * (1 - p)) < EPSILON * countNum){
+                countNum += node.second;
+            }
+            else{
+                if(queryDepth >= MAX_QUERY_DEPTH){   
+                    break;
+                }
+                // split triangle
+                queue.push_back(std::make_pair(DirTriangle(node.first.edgeMidPoint(0), node.first.edgeMidPoint(1), node.first.edgeMidPoint(2)),
+                                                (uint32_t)(node.second * queryPs[queryDepth].x)));
+                queue.push_back(std::make_pair(DirTriangle(node.first.edgeMidPoint(0), node.first.edgeMidPoint(2), node.first[0]),
+                                                (uint32_t)(node.second * queryPs[queryDepth].y)));      
+                queue.push_back(std::make_pair(DirTriangle(node.first.edgeMidPoint(0), node.first.edgeMidPoint(1), node.first[1]),
+                                                (uint32_t)(node.second * queryPs[queryDepth].z))); 
+                queue.push_back(std::make_pair(DirTriangle(node.first.edgeMidPoint(1), node.first.edgeMidPoint(2), node.first[2]),
+                                                (uint32_t)(node.second * (1- queryPs[0].x - queryPs[0].y - queryPs[0].z))));     
+                queryDepth++;                                                           
+            }
+        }
+    }
+    return (double)countNum / DIRECTION_SAMPLE_NUM;
+}
+
+Spectrum GlintBxDF::f(const Vec3d & out, const Vec3d & in) const {
+   if(out.z<0 || in.z<0)
+        return {0.};
+    double cosThetaO = AbsCosTheta(out), cosThetaI = AbsCosTheta(in);
+    Vec3d wh = in + out;
+    // Handle degenerate cases for microfacet reflection
+    if (cosThetaI == 0 || cosThetaO == 0) return {0.};
+    if (wh.x == 0 && wh.y == 0 && wh.z == 0) return {0.};
+    wh = normalize(wh);
+    double cosI = dot(out,wh.z>0?wh:-wh);
+    auto F = Fresnel::conductorReflectance(eta,k,cosI);
+    auto G = distrib->G(out, in,alphaXY);
+
+    double du = (it.dudx + it.dudy) / 2, dv = (it.dvdx + it.dvdy) / 2;
+    BoundingBox2d texBox;
+    texBox = BoundingBoxPointUnion(texBox, Point2d(du, dv));
+    texBox = BoundingBoxPointUnion(texBox, Point2d(-du, dv));
+    texBox = BoundingBoxPointUnion(texBox, Point2d(du, -dv));
+    texBox = BoundingBoxPointUnion(texBox, Point2d(-du, -dv));
+
+    double D = count_direction(in, out);
+    D *= count_spatial(texBox);
+    if(D < 1e-8)
+        return {0.};
+    return albedo * (dot(in,wh) * F * D * G) / 
+            (texBox.getSurfaceArea() * M_PI * (1 - cos(GAMMA)) * cosThetaI * cosThetaO);
+}

--- a/src/FunctionLayer/Material/BxDF/GlintBxDF.h
+++ b/src/FunctionLayer/Material/BxDF/GlintBxDF.h
@@ -1,0 +1,166 @@
+#pragma once
+#include "BxDF.h"
+#include "MicrofacetDistribution.h"
+#include "../../Intersection.h"
+#include "CoreLayer/Geometry/BoundingBox.h"
+#include <random>
+
+#define MAX_QUERY_DEPTH 1000
+#define SPATIAL_SAMPLE_NUM 10000000
+#define DIRECTION_SAMPLE_NUM 10000000
+#define EPSILON 0.1f
+#define GAMMA 0.087f
+#define Spherical2Cartesian(dir) Point3d(cosf(dir.x)*sinf(dir.y),sinf(dir.x)*sinf(dir.y),cosf(dir.y))
+
+// init posibilities in each depth query
+static std::vector<Point3d>  queryPs;
+static int initQueryPs = [](){
+    std::random_device rd;
+    std::mt19937 eng(rd());
+    std::uniform_real_distribution<double> distr(0.f, 1.f);
+    double x, y, z, variance, max;
+
+    for (int i = 0; i < MAX_QUERY_DEPTH;) {
+        x = distr(eng);
+        y = (1 - x) * distr(eng);
+        z = (1 - x - y) * distr(eng);
+        variance = ((x - 0.25)*(x - 0.25) + (y - 0.25)*(y - 0.25) + (z - 0.25)*(z - 0.25) + (0.75 - x - y - z)*(0.75 - x - y - z)) / 4;
+        // when i small, the variance should also be small
+        max = 0.05 + (i * 10 / MAX_QUERY_DEPTH * 0.1);
+        if(variance < max * max) {
+            queryPs.push_back(Point3d(x, y, z));
+            i++;
+        }
+    }
+
+    return 0;
+}();
+
+// dirction trianle for dirction query
+struct DirTriangle{
+    Point2d verts[3];
+
+    DirTriangle(){
+        verts[0] = Point2d(0.f, 0.f), verts[1] = Point2d(0.f, 0.f), verts[2] = Point2d(0.f, 0.f);
+    }
+    DirTriangle(const Point2d &p1, const Point2d &p2, const Point2d &p3){
+        verts[0] = p1, verts[1] = p2, verts[2] = p3;
+    }
+    // top point's x value is meaningless
+    bool isTopPoint(int index) const{
+        return fabs(verts[index].y - M_PI / 2) < 1e-4;
+    }
+    Point2d edgeMidPoint(int index) const{
+        int i = index, j = (index + 1) % 3;
+        if(isTopPoint(i))
+            return Point2d(verts[j].x , 0.5 * (verts[i].y + verts[j].y));
+        else if(isTopPoint(j))
+            return Point2d(verts[i].x , 0.5 * (verts[i].y + verts[j].y));
+        else
+            return Point2d(0.5 * (verts[i].x + verts[j].x), 0.5 * (verts[i].y + verts[j].y));
+    }
+
+    Point2d operator[](int index) const{
+        assert(index >= 0 && index < 3);
+        return verts[index];
+    }
+};
+
+// dirction query struct
+struct ConicQuery{
+    Vec3d wi, wo;
+    Eigen::Matrix3d C;
+
+    ConicQuery(const Vec3d &_wi, const Vec3d &_wo): wi(_wi), wo(_wo){
+        Vec3d x = normalize(cross(wi,wo)), y = normalize(wi - wo), z = normalize(wi + wo);
+        double lambda1 = (dot(wi, wo) + cosf(GAMMA)) / (1 - cosf(GAMMA)), lambda2 = 1.f / (tanf(GAMMA/2)*tanf(GAMMA/2));
+        Eigen::Matrix3d Q, A, QTranspose;
+        Q << x[0], y[0], z[0],
+             x[1], y[1], z[1], 
+             x[2], y[2], z[2];
+        A << lambda1, 0.f, 0.f,
+             0.f, lambda2, 0.f, 
+             0.f, 0.f, -1.f;
+        C = Q;
+        C *= A;
+        QTranspose = Q.transpose();
+        C *= QTranspose;
+    }
+
+    //judge if a point falls in cone
+    bool inConic(const Point2d &p) const{
+        Point3d dir = Spherical2Cartesian(p);
+        Eigen::Vector3d m = Eigen::Vector3d(dir[0], dir[1], dir[2]);
+        return (m.transpose() * C * m) < 0.f;
+    }
+
+    //judge if triangle intersects cone 
+    //not used yet
+    bool IntersectConic(const DirTriangle &_tri) const{
+        Point3d tri[3] = {Spherical2Cartesian(_tri[0]), Spherical2Cartesian(_tri[1]), Spherical2Cartesian(_tri[2])};
+        Eigen::Vector3d c, d;
+        Vec3d _c, _d;
+        double param_a, param_b, param_c, axis;
+        for(int i = 0; i < 3; i++)
+        {
+            _c = tri[i] + tri[(i + 1) % 3] - Point3d(0.f, 0.f, 0.f);
+            _d = tri[i] - tri[(i + 1) % 3];
+            c = Eigen::Vector3d(_c[0], _c[1], _c[2]);
+            d = Eigen::Vector3d(_d[0], _d[1], _d[2]);
+            // The three coefficients of the equation
+            param_a = d.transpose() * C * d;
+            param_b = d.transpose() * C * c;
+            param_b *= 2.f;
+            param_c = c.transpose() * C * c;
+
+            // root in [-1, 1]
+            if((param_a - param_b + param_c) * (param_a + param_b + param_c) < 0.f)
+                return true;
+            else
+            {
+                axis = - param_b / (2 * param_a);
+                if(axis < -1.f || axis > 2.f || 4.f * param_a * param_c - param_b * param_b >= 0.f)
+                    continue;
+                else
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    bool conicContain(const DirTriangle &_tri) const{
+        return (inConic(_tri[0]) && inConic(_tri[1]) && inConic(_tri[2]));
+    }
+};
+
+// bfs tree node: range and particles number in it
+typedef std::pair<BoundingBox2d, uint32_t> SpatialNode;
+typedef std::pair<DirTriangle, uint32_t> DirectionNode;
+
+class GlintBxDF : public  BxDF{
+public:
+    GlintBxDF(Vec3d  _eta,Vec3d _k,Spectrum _albedo, double _uRoughness,double _vRoughness,Intersection _it,
+                       std::shared_ptr<MicrofacetDistribution> _distrib);
+
+    Spectrum f(const Vec3d & out, const Vec3d & in) const override;
+
+    double pdf(const Vec3d & out, const Vec3d & in) const override;
+
+    BxDFSampleResult sample(const Vec3d & out, const Point2d & sample) const override;
+
+    double count_spatial(BoundingBox2d &queryBox) const;
+    
+    double count_direction(const Vec3d &wi, const Vec3d & wo) const;
+
+    [[nodiscard]]
+    double getRoughness() const override { return (alphaXY[0] + alphaXY[1]) / 2.; }
+
+protected:
+    std::shared_ptr<MicrofacetDistribution> distrib;
+    Vec2d alphaXY;
+    Vec3d eta;
+    Vec3d k;
+    Spectrum albedo;
+    Intersection it;
+};
+

--- a/src/FunctionLayer/Material/ConductorMaterial.cpp
+++ b/src/FunctionLayer/Material/ConductorMaterial.cpp
@@ -1,6 +1,7 @@
 #include "ConductorMaterial.h"
 #include "FunctionLayer/Texture/Texture.h"
 #include "BxDF/ConductorBxDF.h"
+#include "BxDF/GlintBxDF.h"
 #include "BxDF/MicrofacetDistribution.h"
 #include "FunctionLayer/Texture/TextureFactory.h"
 #include "FunctionLayer/Material/BxDF/ComplexIor.h"
@@ -9,6 +10,8 @@ std::shared_ptr < BxDF > ConductorMaterial::getBxDF(const Intersection & interse
     if( roughness || uRoughness || vRoughness){
         double  uRough = uRoughness?uRoughness->eval(intersect):roughness->eval(intersect);
         double  vRough = uRoughness?uRoughness->eval(intersect):roughness->eval(intersect);
+        if(glint)
+            return std::make_shared <GlintBxDF>(eta,k,itsAlbedo, uRough, vRough, intersect, distrib);
         return std::make_shared <RoughConductorBxDF>(eta,k,itsAlbedo,uRough,vRough,distrib);
         //Rough conductor
     }
@@ -31,6 +34,7 @@ ConductorMaterial::ConductorMaterial(const Json & json): Material(json) {
                                       2.1421879552f));
     conductorName = getOptional(json,"conductor",std::string());
     conductorName = getOptional(json,"material",conductorName);
+    glint = getOptional(json, "glint", false);
     if(json.contains("roughness"))
         roughness = TextureFactory::LoadTexture<double>(json["roughness"]);
     if(json.contains("u_roughness"))

--- a/src/FunctionLayer/Material/ConductorMaterial.h
+++ b/src/FunctionLayer/Material/ConductorMaterial.h
@@ -34,4 +34,5 @@ private:
     Vec3d k;
     std::string conductorName;
     std::shared_ptr<Texture<RGB3>> albedo;
+    bool glint;
 };


### PR DESCRIPTION
1.实现了简单的2D包围盒
2.实现了光线微分（参考了lite），新增计算光线微分的针孔摄像机
3.在这些基础上实现了导体表面的闪光效果
选择铜为材料，粗糙度设为0.3时效果对比如下：
![teapot1](https://github.com/NJUCG/Moer/assets/94390318/ba91b9e4-6438-4db4-b07c-3b1ae3b0efe1)
![teapot2](https://github.com/NJUCG/Moer/assets/94390318/346d74c1-9b0d-4bd3-89be-35175491bcbc)
