### PR TITLE
feat: limit debug output to Debug mode only

### DIFF
--- a/src/FunctionLayer/Film/Film.cpp
+++ b/src/FunctionLayer/Film/Film.cpp
@@ -40,14 +40,17 @@ void Film::deposit(const Point2i &p, const Spectrum &s) {
 
 void Film::save(const std::string &path) {
     // ! A temp implementation
+#ifdef _DEBUG
     std::ofstream ofs("render_result.txt");
+#endif
     for (int i = 0; i < resolution.y; i++) {
         for (int j = 0; j < resolution.x; j++) {
             int id = i * resolution.x + j;
             Spectrum value = sumValues[id] / sumWeights[id];
             image->setColorAt(Point2i(j, i), value);
-            // for debug
-            ofs << j << " " << i << " " << value[0] << " " << value[1] << " " << value[2] << " " << std::endl;
+#ifdef _DEBUG
+             ofs << j << " " << i << " " << value[0] << " " << value[1] << " " << value[2] << " " << std::endl;
+#endif
         }
     }
     image->saveTo(path);


### PR DESCRIPTION
This commit modifies the `Film::save` function to restrict debug output to Debug mode only. This is achieved by wrapping the debug output code with `#ifdef _DEBUG` preprocessor directives.