### PR TITLE
bugfix: prevent image loading crash when actual channel is not three

### DIFF
--- a/src/ResourceLayer/File/Image.cpp
+++ b/src/ResourceLayer/File/Image.cpp
@@ -25,14 +25,14 @@ Image::Image(const std::string &path, ImageLoadMode ilm) {
     isHdr = stbi_is_hdr(path.c_str());
     int w, h, c;
     if (isHdr) {
-        float *data = stbi_loadf(path.c_str(), &w, &h, &c, 3);
+        float *data = stbi_loadf(path.c_str(), &w, &h, &c, 0);
         imageRawData = new float[w * h * c];
         std::memcpy(imageRawData, data, w * h * c * sizeof(float));
         free(data);
     } else
     // todo: bw mode
     {
-        unsigned char *data = stbi_load(path.c_str(), &w, &h, &c, 3);
+        unsigned char *data = stbi_load(path.c_str(), &w, &h, &c, 0);
         if (!data) {
             std::cout << "Fail to load image " << path << std::endl;
             return;


### PR DESCRIPTION
Fix an issue in the `stbi_loadf` and `stbi_load` functions where the last parameter was incorrectly set to three. This caused the "data" array to always have three channels, rather than the expected "c" channels.